### PR TITLE
Disable health test while it's being fixed.

### DIFF
--- a/auth-app/src/test/java/org/gameontext/auth/HealthTest.java
+++ b/auth-app/src/test/java/org/gameontext/auth/HealthTest.java
@@ -4,6 +4,7 @@ import javax.naming.InitialContext;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -13,6 +14,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
 
+@Ignore
 public class HealthTest {
     
     @Mocked


### PR DESCRIPTION
Seems mocking InitialContext on the IBM JDK leads to badness. 
Investigating, but since this breaks the production build, and my local build, in the meantime, proposing to disable this test.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-auth/19)
<!-- Reviewable:end -->
