### PR TITLE
ICS Deploy Update

### DIFF
--- a/auth-wlpcfg/startup.sh
+++ b/auth-wlpcfg/startup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Configure our link to etcd based on shared volume with secret
+if [ ! -z "$ETCD_SECRET" ]; then
+  . /data/primordial/setup.etcd.sh /data/primordial $ETCD_SECRET
+fi
+
 # Configure amalgam8 for this container
 export A8_SERVICE=auth:v1
 export A8_ENDPOINT_PORT=9443


### PR DESCRIPTION
When running in ICS we'll need to use client certificates to talk to ICS.
These certs are stored encrypted on a volume mapped into the service container at /data
A utility script lives in the container that can decrypt the certs and configure the environment vars for etcdctl to function as expected.
We can identify when we need to run this script, by the presence of the the ETCD_SECRET environment var, which carries the password required to decrypt the certificates. When this is set, we'll launch the utility script, and let it configure our environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-auth/22)
<!-- Reviewable:end -->
