### PR TITLE
Allow cert.pem processing for non etcd launched containers

### DIFF
--- a/auth-wlpcfg/startup.sh
+++ b/auth-wlpcfg/startup.sh
@@ -24,16 +24,8 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
       RC=$?
   done
   echo "etcdctl returned sucessfully, continuing"
-
-  mkdir -p ${SERVER_PATH}/resources/security
-  cd ${SERVER_PATH}/resources/
-  etcdctl get /proxy/third-party-ssl-cert > cert.pem
-  openssl pkcs12 -passin pass:keystore -passout pass:keystore -export -out cert.pkcs12 -in cert.pem
-  keytool -import -v -trustcacerts -alias default -file cert.pem -storepass truststore -keypass keystore -noprompt -keystore security/truststore.jks
-  keytool -genkey -storepass testOnlyKeystore -keypass wefwef -keyalg RSA -alias endeca -keystore security/key.jks -dname CN=rsssl,OU=unknown,O=unknown,L=unknown,ST=unknown,C=CA
-  keytool -delete -storepass testOnlyKeystore -alias endeca -keystore security/key.jks
-  keytool -v -importkeystore -srcalias 1 -alias 1 -destalias default -noprompt -srcstorepass keystore -deststorepass testOnlyKeystore -srckeypass keystore -destkeypass testOnlyKeystore -srckeystore cert.pkcs12 -srcstoretype PKCS12 -destkeystore security/key.jks -deststoretype JKS
-  cd ${SERVER_PATH}
+  mkdir -p /etc/cert
+  etcdctl get /proxy/third-party-ssl-cert > /etc/cert/cert.pem
 
   export SYSTEM_ID=$(etcdctl get /global/system_id)
 
@@ -66,6 +58,26 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
   export MESSAGEHUB_USER=$(etcdctl get /kafka/user)
   export MESSAGEHUB_PASSWORD=$(etcdctl get /passwords/kafka)
   wget https://github.com/ibm-messaging/message-hub-samples/raw/master/java/message-hub-liberty-sample/lib-message-hub/messagehub.login-1.0.0.jar
+fi
+
+if [ -f /etc/cert/cert.pem ]; then
+  echo "Building keystore/truststore from cert.pem"
+  echo "-creating dir"
+  mkdir -p ${SERVER_PATH}/resources/security
+  echo "-cd dir"
+  cd ${SERVER_PATH}/resources/
+  echo "-converting pem to pkcs12"
+  openssl pkcs12 -passin pass:keystore -passout pass:keystore -export -out cert.pkcs12 -in /etc/cert/cert.pem
+  echo "-importing pem to truststore.jks"
+  keytool -import -v -trustcacerts -alias default -file /etc/cert/cert.pem -storepass truststore -keypass keystore -noprompt -keystore security/truststore.jks
+  echo "-creating dummy key.jks"
+  keytool -genkey -storepass testOnlyKeystore -keypass wefwef -keyalg RSA -alias endeca -keystore security/key.jks -dname CN=rsssl,OU=unknown,O=unknown,L=unknown,ST=unknown,C=CA
+  echo "-emptying key.jks"
+  keytool -delete -storepass testOnlyKeystore -alias endeca -keystore security/key.jks
+  echo "-importing pkcs12 to key.jks"
+  keytool -v -importkeystore -srcalias 1 -alias 1 -destalias default -noprompt -srcstorepass keystore -deststorepass testOnlyKeystore -srckeypass keystore -destkeypass testOnlyKeystore -srckeystore cert.pkcs12 -srcstoretype PKCS12 -destkeystore security/key.jks -deststoretype JKS
+  echo "done"
+  cd ${SERVER_PATH}
 fi
 
 exec /opt/ibm/wlp/bin/server run defaultServer


### PR DESCRIPTION
Originally only etcd containers used cert.pem as a source for certificates, but it's looking like that logic should be common for other launch types, like k8s, and should possibly become the norm for docker-compose too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-auth/30)
<!-- Reviewable:end -->
