### PR TITLE
Message hub jar lives in server path

### DIFF
--- a/auth-wlpcfg/startup.sh
+++ b/auth-wlpcfg/startup.sh
@@ -57,6 +57,7 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
   #from github, and have to use an extra config snippet to enable it.
   export MESSAGEHUB_USER=$(etcdctl get /kafka/user)
   export MESSAGEHUB_PASSWORD=$(etcdctl get /passwords/kafka)
+  cd ${SERVER_PATH}
   wget https://github.com/ibm-messaging/message-hub-samples/raw/master/java/message-hub-liberty-sample/lib-message-hub/messagehub.login-1.0.0.jar
 fi
 


### PR DESCRIPTION
Previous cert change missed that the client jar needed to be in server path

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-auth/31)
<!-- Reviewable:end -->
